### PR TITLE
gui/Properties: Don't expand memory patterns too far

### DIFF
--- a/src/com/ra4king/circuitsim/gui/Properties.java
+++ b/src/com/ra4king/circuitsim/gui/Properties.java
@@ -592,7 +592,7 @@ public class Properties {
 					String[] split = piece.split("-");
 					int count = Integer.parseInt(split[0]);
 					int val = parseValue(split[1]);
-					for(int j = 0; j < count; j++, i++) {
+					for(int j = 0; j < count && i < values.length; j++, i++) {
 						values[i] = val;
 					}
 					i--; // to account for extra increment


### PR DESCRIPTION
Currently, when you place a new ROM component, it defaults to having an 8-bit address, so the component has its Contents property set to `256-0` since 19b5fa8ade. However, if you then set the component's address bits to 4, PropertyMemoryValidator.parse() attempt to expand this `256-0` pattern past the end of the backing array of size 16, raising an ArrayIndexOutOfBoundsException. This makes it impossible to shrink the address bits of a ROM component.

So stop expanding a memory pattern thing when the backing array is full.