### PR TITLE
Requests from 2200: Show address/value for RAM/ROM, support pasting memory

### DIFF
--- a/src/com/ra4king/circuitsim/gui/peers/memory/RAMPeer.java
+++ b/src/com/ra4king/circuitsim/gui/peers/memory/RAMPeer.java
@@ -14,6 +14,7 @@ import com.ra4king.circuitsim.gui.Properties;
 import com.ra4king.circuitsim.gui.Properties.MemoryLine;
 import com.ra4king.circuitsim.gui.Properties.PropertyMemoryValidator;
 import com.ra4king.circuitsim.simulator.CircuitState;
+import com.ra4king.circuitsim.simulator.WireValue;
 import com.ra4king.circuitsim.simulator.components.memory.RAM;
 
 import javafx.geometry.Bounds;
@@ -34,7 +35,7 @@ public class RAMPeer extends ComponentPeer<RAM> {
 	}
 	
 	public RAMPeer(Properties props, int x, int y) {
-		super(x, y, 5, 4);
+		super(x, y, 9, 5);
 		
 		Properties properties = new Properties();
 		properties.ensureProperty(Properties.LABEL);
@@ -50,10 +51,10 @@ public class RAMPeer extends ComponentPeer<RAM> {
 		
 		List<PortConnection> connections = new ArrayList<>();
 		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_ADDRESS), "Address", 0, 2));
-		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_CLK), "Clock", 1, getHeight()));
-		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_ENABLE), "Enable", 2, getHeight()));
-		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_LOAD), "Load", 3, getHeight()));
-		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_CLEAR), "Clear", 4, getHeight()));
+		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_CLK), "Clock", 3, getHeight()));
+		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_ENABLE), "Enable", 4, getHeight()));
+		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_LOAD), "Load", 5, getHeight()));
+		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_CLEAR), "Clear", 6, getHeight()));
 		connections.add(new PortConnection(this, ram.getPort(RAM.PORT_DATA), "Data", getWidth(), 2));
 		
 		init(ram, properties, connections);
@@ -94,12 +95,38 @@ public class RAMPeer extends ComponentPeer<RAM> {
 		
 		graphics.setStroke(Color.BLACK);
 		GuiUtils.drawShape(graphics::strokeRect, this);
-		
+
+		WireValue addressVal = circuitState.getLastReceived(getComponent().getPort(RAM.PORT_ADDRESS));
+		WireValue valueVal;
+		if (addressVal.isValidValue()) {
+			int val = getComponent().load(circuitState, addressVal.getValue());
+			valueVal = WireValue.of(val, getComponent().getDataBits());
+		} else {
+			valueVal = new WireValue(getComponent().getDataBits());
+		}
+		String address = addressVal.toHexString();
+		String value = valueVal.toHexString();
+
+		int x = getScreenX();
+		int y = getScreenY();
+		int width = getScreenWidth();
+		int height = getScreenHeight();
+
 		String text = "RAM";
 		Bounds bounds = GuiUtils.getBounds(graphics.getFont(), text);
 		graphics.setFill(Color.BLACK);
 		graphics.fillText(text,
-		                  getScreenX() + (getScreenWidth() - bounds.getWidth()) * 0.5,
-		                  getScreenY() + (getScreenHeight() + bounds.getHeight()) * 0.45);
+		                  x + (width - bounds.getWidth()) * 0.5,
+		                  y + (height + bounds.getHeight()) * 0.2);
+
+		graphics.setFont(GuiUtils.getFont(11));
+		// Draw address
+		text = "A: " + address;
+		double addrY = y + bounds.getHeight() + 15;
+		graphics.fillText(text, x + 10, addrY);
+
+		// Draw data afterward
+		bounds = GuiUtils.getBounds(graphics.getFont(), text);
+		graphics.fillText("D: " + value, x + 10, addrY + bounds.getHeight());
 	}
 }

--- a/src/com/ra4king/circuitsim/gui/peers/memory/ROMPeer.java
+++ b/src/com/ra4king/circuitsim/gui/peers/memory/ROMPeer.java
@@ -36,7 +36,7 @@ public class ROMPeer extends ComponentPeer<ROM> {
 	private final Property<List<MemoryLine>> contentsProperty;
 	
 	public ROMPeer(Properties props, int x, int y) {
-		super(x, y, 5, 4);
+		super(x, y, 9, 5);
 		
 		Properties properties = new Properties();
 		properties.ensureProperty(Properties.LABEL);
@@ -65,7 +65,7 @@ public class ROMPeer extends ComponentPeer<ROM> {
 		
 		List<PortConnection> connections = new ArrayList<>();
 		connections.add(new PortConnection(this, ram.getPort(ROM.PORT_ADDRESS), "Address", 0, 2));
-		connections.add(new PortConnection(this, ram.getPort(ROM.PORT_ENABLE), "Enable", 2, getHeight()));
+		connections.add(new PortConnection(this, ram.getPort(ROM.PORT_ENABLE), "Enable", 3, getHeight()));
 		connections.add(new PortConnection(this, ram.getPort(ROM.PORT_DATA), "Data", getWidth(), 2));
 		
 		init(ram, properties, connections);
@@ -122,12 +122,30 @@ public class ROMPeer extends ComponentPeer<ROM> {
 		
 		graphics.setStroke(Color.BLACK);
 		GuiUtils.drawShape(graphics::strokeRect, this);
+
+		String address = circuitState.getLastReceived(getComponent().getPort(ROM.PORT_ADDRESS)).toHexString();
+		String value = circuitState.getLastPushed(getComponent().getPort(ROM.PORT_DATA)).toHexString();
 		
+		int x = getScreenX();
+		int y = getScreenY();
+		int width = getScreenWidth();
+		int height = getScreenHeight();
+
 		String text = "ROM";
 		Bounds bounds = GuiUtils.getBounds(graphics.getFont(), text);
 		graphics.setFill(Color.BLACK);
 		graphics.fillText(text,
-		                    getScreenX() + (getScreenWidth() - bounds.getWidth()) * 0.5,
-		                    getScreenY() + (getScreenHeight() + bounds.getHeight()) * 0.45);
+		                  x + (width - bounds.getWidth()) * 0.5,
+		                  y + (height + bounds.getHeight()) * 0.2);
+
+		graphics.setFont(GuiUtils.getFont(11));
+		// Draw address
+		text = "A: " + address;
+		double addrY = y + bounds.getHeight() + 15;
+		graphics.fillText(text, x + 10, addrY);
+
+		// Draw data afterward
+		bounds = GuiUtils.getBounds(graphics.getFont(), text);
+		graphics.fillText("D: " + value, x + 10, addrY + bounds.getHeight());
 	}
 }

--- a/src/com/ra4king/circuitsim/gui/peers/memory/RegisterPeer.java
+++ b/src/com/ra4king/circuitsim/gui/peers/memory/RegisterPeer.java
@@ -123,18 +123,7 @@ public class RegisterPeer extends ComponentPeer<Register> {
 		graphics.setFill(Color.WHITE);
 		GuiUtils.drawShape(graphics::fillRect, this);
 		
-		WireValue lastPushedValue = circuitState.getLastPushed(getComponent().getPort(Register.PORT_OUT));
-		String value;
-		int hexDigits = 1 + (getComponent().getBitSize() - 1) / 4;
-		if(lastPushedValue.isValidValue()) {
-			int num = lastPushedValue.getValue();
-			value = String.format("%0" + hexDigits + "x", num);
-		} else {
-			value = "";
-			for(int i = 0; i < hexDigits; i++) {
-				value += "x";
-			}
-		}
+		String value = circuitState.getLastPushed(getComponent().getPort(Register.PORT_OUT)).toHexString();
 		
 		int x = getScreenX();
 		int y = getScreenY();

--- a/src/com/ra4king/circuitsim/simulator/WireValue.java
+++ b/src/com/ra4king/circuitsim/simulator/WireValue.java
@@ -147,7 +147,27 @@ public class WireValue {
 		}
 		return value;
 	}
-	
+
+	/**
+	 * Converts the value held on this wire to a hex string.
+	 *
+	 * @return a lowercase hex string if all bits are defined, otherwise
+	 *         getBitSize() 'x's
+	 */
+	public String toHexString() {
+		String value;
+		int hexDigits = 1 + (getBitSize() - 1) / 4;
+		if(isValidValue()) {
+			value = String.format("%0" + hexDigits + "x", getValue());
+		} else {
+			value = "";
+			for(int i = 0; i < hexDigits; i++) {
+				value += "x";
+			}
+		}
+		return value;
+	}
+
 	@Override
 	public boolean equals(Object other) {
 		if(other instanceof WireValue) {


### PR DESCRIPTION
From the head TA of 2200 a few hours ago:

> so I think the big thing that seems to be missing from circuitsim that we need is a way to copy and paste into the ram and rom (if it's there I can't see it)
> there's a feature to load and save to a file but that's both an extra step and the format that it requires doesn't jive super well with the excel spreadsheet method we have
> also I like that in logisim you can easily see the contents in hex and which address is being accessed
> I think if in the future the rams and roms have a little bit more of that functionality to them then we'd be ready to switch, but idk rn
> 
> if I end up having time maybe I'd be down to contribute to a 2200 fork or something, it looks like it's all javafx and I'm pretty comfortable with that

(I sent you an invite to the slack where we're discussing it)

So this PR adds an address/data view that looks like:

![image](https://user-images.githubusercontent.com/431756/44185412-09119380-a0e2-11e8-9aa1-8549fa47986b.png)

and allows you to paste memory values in the memory view.

Some of my code is kind of rough but I'm hoping it's a good starting point