### PR TITLE
CircuitSim: Expose CircuitManagers to anybody

### DIFF
--- a/src/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -463,7 +463,7 @@ public class CircuitSim extends Application {
 		       : circuitManagers.get(tab.getText()).getValue();
 	}
 	
-	String getCircuitName(CircuitManager manager) {
+	public String getCircuitName(CircuitManager manager) {
 		for(Entry<String, Pair<ComponentLauncherInfo, CircuitManager>> entry : circuitManagers.entrySet()) {
 			if(entry.getValue().getValue() == manager) {
 				return entry.getKey();
@@ -472,12 +472,20 @@ public class CircuitSim extends Application {
 		
 		return null;
 	}
+
+    public Map<String, CircuitManager> getCircuitManagers() {
+		return circuitManagers.keySet().stream()
+		                      .collect(Collectors.toMap(name -> name,
+		                                                name -> circuitManagers.get(name).getValue(),
+		                                                (v1, v2) -> v1,
+		                                                LinkedHashMap::new));
+    }
 	
-	CircuitManager getCircuitManager(String name) {
+	public CircuitManager getCircuitManager(String name) {
 		return circuitManagers.containsKey(name) ? circuitManagers.get(name).getValue() : null;
 	}
 	
-	CircuitManager getCircuitManager(Circuit circuit) {
+	public CircuitManager getCircuitManager(Circuit circuit) {
 		for(Entry<String, Pair<ComponentLauncherInfo, CircuitManager>> entry : circuitManagers.entrySet()) {
 			if(entry.getValue().getValue().getCircuit() == circuit) {
 				return entry.getValue().getValue();

--- a/src/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -474,11 +474,9 @@ public class CircuitSim extends Application {
 	}
 
     public Map<String, CircuitManager> getCircuitManagers() {
-		return circuitManagers.keySet().stream()
-		                      .collect(Collectors.toMap(name -> name,
-		                                                name -> circuitManagers.get(name).getValue(),
-		                                                (v1, v2) -> v1,
-		                                                LinkedHashMap::new));
+		return circuitManagers.entrySet().stream()
+		                      .collect(Collectors.toMap(entry -> entry.getKey(),
+		                                                entry -> entry.getValue().getValue()));
     }
 	
 	public CircuitManager getCircuitManager(String name) {


### PR DESCRIPTION
Allow others to get a map of subcircuit names to CircuitManagers, and
provide them by name on request. This makes poking around with
CircuitManagers (which include the Canvas and thus the Canvas size)
possible.