### PR TITLE
Draw fake wires between port and gate when one input is bubbled

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/gui/peers/gates/GatePeer.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/peers/gates/GatePeer.java
@@ -144,9 +144,9 @@ public abstract class GatePeer<T extends Gate> extends ComponentPeer<T> {
 	@Override
 	public final void paint(GraphicsContext graphics, CircuitState circuitState) {
 		for (int i = 0; i < getConnections().size() - 1; i++) {
-			PortConnection c = getConnections().get(i);
-			int x = c.getX() * GuiUtils.BLOCK_SIZE;
-			int y = c.getY() * GuiUtils.BLOCK_SIZE;
+			PortConnection portConnection = getConnections().get(i);
+			int x = portConnection.getX() * GuiUtils.BLOCK_SIZE;
+			int y = portConnection.getY() * GuiUtils.BLOCK_SIZE;
 
 			if (getComponent().getNegateInputs()[i]) {
 				graphics.setFill(Color.WHITE);
@@ -170,24 +170,19 @@ public abstract class GatePeer<T extends Gate> extends ComponentPeer<T> {
 				graphics.strokeOval(x, y, GuiUtils.BLOCK_SIZE, GuiUtils.BLOCK_SIZE);
 			} else if (hasNegatedInput) {
 				// Imitate how a wire is drawn in Wire.paint()
-				GuiUtils.setBitColor(graphics, circuitState, c.getLinkWires());
+				GuiUtils.setBitColor(graphics, circuitState.getLastReceived(portConnection.getPort()));
 				graphics.setLineWidth(2.0);
 
-				int dx = 0, dy = 0;
-				switch (getProperties().getValue(Properties.DIRECTION)) {
-					case WEST:
-						dx = -GuiUtils.BLOCK_SIZE;
-						break;
-					case EAST:
-						dx = GuiUtils.BLOCK_SIZE;
-						break;
-					case NORTH:
-						dy = -GuiUtils.BLOCK_SIZE;
-						break;
-					case SOUTH:
-						dy = GuiUtils.BLOCK_SIZE;
-						break;
-				}
+				int dx = switch (getProperties().getValue(Properties.DIRECTION)) {
+					case WEST -> -GuiUtils.BLOCK_SIZE;
+					case EAST -> GuiUtils.BLOCK_SIZE;
+					default -> 0;
+				};
+				int dy = switch (getProperties().getValue(Properties.DIRECTION)) {
+					case NORTH -> -GuiUtils.BLOCK_SIZE;
+					case SOUTH -> GuiUtils.BLOCK_SIZE;
+					default -> 0;
+				};
 
 				graphics.strokeLine(x, y, x + dx, y + dy);
 			}

--- a/src/main/java/com/ra4king/circuitsim/gui/peers/gates/GatePeer.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/peers/gates/GatePeer.java
@@ -143,15 +143,16 @@ public abstract class GatePeer<T extends Gate> extends ComponentPeer<T> {
 	
 	@Override
 	public final void paint(GraphicsContext graphics, CircuitState circuitState) {
-		graphics.setFill(Color.WHITE);
-		graphics.setStroke(Color.BLACK);
-		
 		for (int i = 0; i < getConnections().size() - 1; i++) {
+			PortConnection c = getConnections().get(i);
+			int x = c.getX() * GuiUtils.BLOCK_SIZE;
+			int y = c.getY() * GuiUtils.BLOCK_SIZE;
+
 			if (getComponent().getNegateInputs()[i]) {
-				PortConnection c = getConnections().get(i);
-				int x = c.getX() * GuiUtils.BLOCK_SIZE;
-				int y = c.getY() * GuiUtils.BLOCK_SIZE;
-				
+				graphics.setFill(Color.WHITE);
+				graphics.setStroke(Color.BLACK);
+				graphics.setLineWidth(1.0);
+
 				switch (getProperties().getValue(Properties.DIRECTION)) {
 					case WEST:
 						x -= GuiUtils.BLOCK_SIZE;
@@ -167,8 +168,33 @@ public abstract class GatePeer<T extends Gate> extends ComponentPeer<T> {
 				
 				graphics.fillOval(x, y, GuiUtils.BLOCK_SIZE, GuiUtils.BLOCK_SIZE);
 				graphics.strokeOval(x, y, GuiUtils.BLOCK_SIZE, GuiUtils.BLOCK_SIZE);
+			} else if (hasNegatedInput) {
+				// Imitate how a wire is drawn in Wire.paint()
+				GuiUtils.setBitColor(graphics, circuitState, c.getLinkWires());
+				graphics.setLineWidth(2.0);
+
+				int dx = 0, dy = 0;
+				switch (getProperties().getValue(Properties.DIRECTION)) {
+					case WEST:
+						dx = -GuiUtils.BLOCK_SIZE;
+						break;
+					case EAST:
+						dx = GuiUtils.BLOCK_SIZE;
+						break;
+					case NORTH:
+						dy = -GuiUtils.BLOCK_SIZE;
+						break;
+					case SOUTH:
+						dy = GuiUtils.BLOCK_SIZE;
+						break;
+				}
+
+				graphics.strokeLine(x, y, x + dx, y + dy);
 			}
 		}
+
+		// Reset the line width to the default after possibly drawing some fake wires above
+		graphics.setLineWidth(1.0);
 		
 		GuiUtils.drawName(graphics, this, getProperties().getValue(Properties.LABEL_LOCATION));
 		GuiUtils.rotateGraphics(this, graphics, getProperties().getValue(Properties.DIRECTION));


### PR DESCRIPTION
Some work at addressing #79. This draws a fake wire to avoids dead space between port and gate that confused students in lecture today.

Not perfect, since this can cause some weird situations as shown at the very bottom below:

![image](https://user-images.githubusercontent.com/431756/190060519-13e330ea-591b-43cf-a0d8-263bd924e991.png)
