### PR TITLE
Allow users to toggle the grid background

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -365,11 +365,7 @@ public class CircuitManager {
 			graphics.setFontSmoothingType(FontSmoothingType.LCD);
 			
 			boolean drawGrid = showGrid.getValue();
-			if (drawGrid) {
-				graphics.setFill(Color.LIGHTGRAY);
-			} else {
-				graphics.setFill(Color.WHITE);
-			}
+			graphics.setFill(drawGrid ? Color.LIGHTGRAY : Color.WHITE);
 			graphics.fillRect(0, 0, getCanvas().getWidth(), getCanvas().getHeight());
 			
 			graphics.scale(simulatorWindow.getScaleFactor(), simulatorWindow.getScaleFactor());

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -20,6 +20,7 @@ import com.ra4king.circuitsim.simulator.Port.Link;
 import com.ra4king.circuitsim.simulator.SimulationException;
 import com.ra4king.circuitsim.simulator.Simulator;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.scene.canvas.Canvas;
@@ -55,6 +56,7 @@ public class CircuitManager {
 	
 	private final CircuitSim simulatorWindow;
 	private final ScrollPane canvasScrollPane;
+	private final BooleanProperty showGrid;
 	private final CircuitBoard circuitBoard;
 	
 	private ContextMenu menu;
@@ -88,9 +90,10 @@ public class CircuitManager {
 	
 	private boolean needsRepaint;
 	
-	CircuitManager(String name, CircuitSim simulatorWindow, ScrollPane canvasScrollPane, Simulator simulator) {
+	CircuitManager(String name, CircuitSim simulatorWindow, ScrollPane canvasScrollPane, Simulator simulator, BooleanProperty showGrid) {
 		this.simulatorWindow = simulatorWindow;
 		this.canvasScrollPane = canvasScrollPane;
+		this.showGrid = showGrid;
 		circuitBoard = new CircuitBoard(name, this, simulator, simulatorWindow.getEditHistory());
 		
 		getCanvas().setOnContextMenuRequested(event -> {
@@ -361,16 +364,23 @@ public class CircuitManager {
 			graphics.setFont(GuiUtils.getFont(13));
 			graphics.setFontSmoothingType(FontSmoothingType.LCD);
 			
-			graphics.setFill(Color.LIGHTGRAY);
+			boolean drawGrid = showGrid.getValue();
+			if (drawGrid) {
+				graphics.setFill(Color.LIGHTGRAY);
+			} else {
+				graphics.setFill(Color.WHITE);
+			}
 			graphics.fillRect(0, 0, getCanvas().getWidth(), getCanvas().getHeight());
 			
 			graphics.scale(simulatorWindow.getScaleFactor(), simulatorWindow.getScaleFactor());
 			
 			graphics.setFill(Color.BLACK);
-			double scaleInverted = simulatorWindow.getScaleFactorInverted();
-			for (int i = 0; i < getCanvas().getWidth() * scaleInverted; i += GuiUtils.BLOCK_SIZE) {
-				for (int j = 0; j < getCanvas().getHeight() * scaleInverted; j += GuiUtils.BLOCK_SIZE) {
-					graphics.fillRect(i, j, 1, 1);
+			if (drawGrid) {
+				double scaleInverted = simulatorWindow.getScaleFactorInverted();
+				for (int i = 0; i < getCanvas().getWidth() * scaleInverted; i += GuiUtils.BLOCK_SIZE) {
+					for (int j = 0; j < getCanvas().getHeight() * scaleInverted; j += GuiUtils.BLOCK_SIZE) {
+						graphics.fillRect(i, j, 1, 1);
+					}
 				}
 			}
 			

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -66,6 +66,8 @@ import com.ra4king.circuitsim.simulator.components.wiring.Pin;
 import javafx.animation.AnimationTimer;
 import javafx.application.Application;
 import javafx.application.Platform;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Orientation;
@@ -156,6 +158,7 @@ public class CircuitSim extends Application {
 	private Simulator simulator;
 	private CheckMenuItem simulationEnabled;
 	
+	private BooleanProperty showGridProp;
 	private MenuItem undo, redo;
 	private CheckMenuItem clockEnabled;
 	private Menu frequenciesMenu;
@@ -412,7 +415,7 @@ public class CircuitSim extends Application {
 	public boolean isSimulationEnabled() {
 		return simulationEnabled.isSelected();
 	}
-	
+
 	private void runSim() {
 		try {
 			if (isSimulationEnabled() && simulator.hasLinksToUpdate()) {
@@ -461,6 +464,10 @@ public class CircuitSim extends Application {
 		}
 		
 		throw new IllegalStateException("This can't happen lol");
+	}
+
+	private void repaintAllCircuits() {
+		simulator.runSync(() -> circuitManagers.values().stream().map(Pair::getValue).forEach(CircuitManager::paint));
 	}
 	
 	private CircuitManager getCurrentCircuit() {
@@ -1736,7 +1743,7 @@ public class CircuitSim extends Application {
 							});
 							
 							// Do an initial paint of all the tabs
-							simulator.runSync(() -> getCircuitManagers().values().forEach(CircuitManager::paint));
+							repaintAllCircuits();
 						});
 						tasksThread.setName("LoadCircuits Tasks Thread");
 						tasksThread.start();
@@ -1983,7 +1990,7 @@ public class CircuitSim extends Application {
 			ScrollPane canvasScrollPane = new ScrollPane(canvas);
 			canvasScrollPane.setFocusTraversable(true);
 			
-			CircuitManager circuitManager = new CircuitManager(n, this, canvasScrollPane, simulator);
+			CircuitManager circuitManager = new CircuitManager(n, this, canvasScrollPane, simulator, showGridProp);
 			circuitManager.getCircuit().addListener(this::circuitModified);
 			
 			canvas.addEventHandler(MouseEvent.ANY, e -> canvas.requestFocus());
@@ -2128,6 +2135,8 @@ public class CircuitSim extends Application {
 		}
 		
 		this.stage = stage;
+		// Default to showing the grid background
+		this.showGridProp = new SimpleBooleanProperty(true);
 		
 		stage.getIcons().add(new Image(getClass().getResourceAsStream("/images/Icon.png")));
 		
@@ -2283,10 +2292,8 @@ public class CircuitSim extends Application {
 		
 		MenuItem print = new MenuItem("Export as Images");
 		print.setOnAction(event -> {
-			simulator.runSync(() -> {
-				// Repaint first, so it can flush while the user chooses an output directory.
-				circuitManagers.values().stream().map(Pair::getValue).forEach(CircuitManager::paint);
-			});
+			// Repaint first, so it can flush while the user chooses an output directory.
+			repaintAllCircuits();
 			
 			DirectoryChooser directoryChooser = new DirectoryChooser();
 			directoryChooser.setTitle("Choose output directory");
@@ -2469,6 +2476,17 @@ public class CircuitSim extends Application {
 		editMenu
 			.getItems()
 			.addAll(undo, redo, new SeparatorMenuItem(), copy, cut, paste, new SeparatorMenuItem(), selectAll);
+
+		// VIEW Menu
+		CheckMenuItem showGrid = new CheckMenuItem("Show grid");
+		showGrid.selectedProperty().bindBidirectional(showGridProp);
+		showGridProp.addListener((observable, oldValue, newValue) -> {
+			// CircuitManagers already have access to showGridProp
+			needsRepaint = true;
+		});
+
+		Menu viewMenu = new Menu("View");
+		viewMenu.getItems().addAll(showGrid);
 		
 		// COMPONENTS Menu
 		MenuItem loadLibrary = new MenuItem("Load library");
@@ -2626,7 +2644,7 @@ public class CircuitSim extends Application {
 		});
 		helpMenu.getItems().addAll(help, checkUpdate, about);
 		
-		MenuBar menuBar = new MenuBar(fileMenu, editMenu, componentsMenu, circuitsMenu, simulationMenu, helpMenu);
+		MenuBar menuBar = new MenuBar(fileMenu, editMenu, viewMenu, componentsMenu, circuitsMenu, simulationMenu, helpMenu);
 		menuBar.setUseSystemMenuBar(true);
 		
 		ScrollPane propertiesScrollPane = new ScrollPane(propertiesTable);


### PR DESCRIPTION
Apparently Prof. Conte "wants gridless CircuitSim himself," so I'm hoping to upstream that to avoid emailing jars around. I didn't ask exactly why he wanted it, but I think this checkbox is useful when combined with 6d58b4218027f806a9.

Here it is in action (I wasn't sure where to put it, so I made a new "View" menu):

![image](https://user-images.githubusercontent.com/431756/210498580-f93d7804-2fb5-4cc6-a898-0ceda3cc8133.png)

![image](https://user-images.githubusercontent.com/431756/210498593-e257e444-1cb2-40b0-b92e-3cc7216c6bd8.png)

To the exporting point, the respective exported images look like:

![grid](https://user-images.githubusercontent.com/431756/210498658-f6182262-298c-4d95-9ec4-e6abc3a59c86.png)

versus

![no-grid](https://user-images.githubusercontent.com/431756/210498683-1e64399e-7489-4331-8b17-05c2751132cc.png)

I think the latter would be easier to read for students if you exported some work from lecture, for example. In particular, I find text easier to read in the latter. (Note that before exporting those images I toggled "view grid" manually, it's not automatic)