### PR TITLE
Throw a slightly more friendly message when a student opens an empty file

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -1474,6 +1474,9 @@ public class CircuitSim extends Application {
 						
 						CircuitFile circuitFile = FileFormat.load(lastSaveFile);
 						
+						if (circuitFile == null) {
+							throw new NullPointerException("File is empty!");
+						}
 						if (circuitFile.circuits == null) {
 							throw new NullPointerException("File missing circuits");
 						}


### PR DESCRIPTION
This error gets propagated to autograders, so a more friendly error message is useful

The current behavior is this, which confuses students:
```
java.lang.NullPointerException: Cannot read field "circuits" because "circuitFile" is null
	at com.ra4king.circuitsim.gui.CircuitSim.lambda$loadCircuits$57(CircuitSim.java:1477)
	at java.base/java.lang.Thread.run(Thread.java:833)
```