### PR TITLE
Add some quality-of-life changes regarding text/selection shortcuts

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -2311,21 +2311,36 @@ public class CircuitSim extends Application {
 		
 		MenuItem copy = new MenuItem("Copy");
 		copy.setAccelerator(new KeyCodeCombination(KeyCode.C, KeyCombination.SHORTCUT_DOWN));
-		copy.setOnAction(event -> copySelectedComponents());
+		copy.setOnAction(event -> {
+			CircuitManager manager = getCurrentCircuit();
+			if (manager != null && manager.getCanvas().isFocused()) {
+				copySelectedComponents();
+			}
+		});
 		
 		MenuItem cut = new MenuItem("Cut");
 		cut.setAccelerator(new KeyCodeCombination(KeyCode.X, KeyCombination.SHORTCUT_DOWN));
-		cut.setOnAction(event -> cutSelectedComponents());
+		cut.setOnAction(event -> {
+			CircuitManager manager = getCurrentCircuit();
+			if (manager != null && manager.getCanvas().isFocused()) {
+				cutSelectedComponents();
+			}
+		});
 		
 		MenuItem paste = new MenuItem("Paste");
 		paste.setAccelerator(new KeyCodeCombination(KeyCode.V, KeyCombination.SHORTCUT_DOWN));
-		paste.setOnAction(event -> pasteFromClipboard());
+		paste.setOnAction(event -> {
+			CircuitManager manager = getCurrentCircuit();
+			if (manager != null && manager.getCanvas().isFocused()) {
+				pasteFromClipboard();
+			}
+		});
 		
 		MenuItem selectAll = new MenuItem("Select All");
 		selectAll.setAccelerator(new KeyCodeCombination(KeyCode.A, KeyCombination.SHORTCUT_DOWN));
 		selectAll.setOnAction(event -> {
 			CircuitManager manager = getCurrentCircuit();
-			if (manager != null) {
+			if (manager != null && manager.getCanvas().isFocused()) {
 				manager.setSelectedElements(Stream
 					                            .concat(manager.getCircuitBoard().getComponents().stream(),
 					                                    manager

--- a/src/main/java/com/ra4king/circuitsim/gui/peers/misc/Text.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/peers/misc/Text.java
@@ -87,29 +87,43 @@ public class Text extends ComponentPeer<Component> {
 		entered = false;
 	}
 	
+	private boolean backspaceDown;
 	@Override
 	public boolean keyPressed(CircuitManager manager, CircuitState state, KeyCode keyCode, String text) {
+		if (keyCode == KeyCode.BACK_SPACE) {
+			backspaceDown = true;
+		}
 		return keyCode == KeyCode.BACK_SPACE && !this.text.isEmpty();
 	}
 	
 	@Override
+	public void keyReleased(CircuitManager manager, CircuitState state, KeyCode keyCode, String text) {
+		if (keyCode == KeyCode.BACK_SPACE) {
+			backspaceDown = false;
+		}
+		super.keyReleased(manager, state, keyCode, text);
+	}
+
+	@Override
 	public void keyTyped(CircuitManager manager, CircuitState state, String character) {
-		char c = character.charAt(0);
-		
-		if (c == 8) { // backspace
-			if (!text.isEmpty()) {
+		if (character.isEmpty()) {
+			if (backspaceDown && !text.isEmpty()) {
 				String s = text.substring(0, text.length() - 1);
 				setText(s);
 				getProperties().setValue(TEXT, s);
 			}
-		} else if (c == 10 || c == 13 || c >= 32 && c <= 126) { // line feed, carriage return, or visible ASCII char 
-			if (c == 13) {
-				c = 10; // convert \r to \n
-			}
+		} else {
+			char c = character.charAt(0);
 			
-			String s = text + c;
-			setText(s);
-			getProperties().setValue(TEXT, s);
+			if (c == 10 || c == 13 || c >= 32 && c <= 126) { // line feed, carriage return, or visible ASCII char 
+				if (c == 13) {
+					c = 10; // convert \r to \n
+				}
+				
+				String s = text + c;
+				setText(s);
+				getProperties().setValue(TEXT, s);
+			}
 		}
 	}
 	


### PR DESCRIPTION
Feature from downstream

## Text Updates

- Typical text-editing shortcuts (Ctrl + A, Ctrl + C, Ctrl + V, Ctrl + X, Ctrl + Z) can now be used in text inputs without activating the canvas shortcuts (e.g., selecting all components).
- Backspace should now work properly on the text component

## Selection Updates

- Ctrl-clicking a component now toggle-selects components
- (macOS) Command-clicking should allow you to select components (which would be done by ctrl-clicking on Windows).
    - Previously, this behavior was _also_ mapped to ctrl-clicking in macOS, but ctrl-clicking also opens a context menu, so this is probably unintended